### PR TITLE
Fix netcat send tiny string on udp

### DIFF
--- a/lib/infrataster/plugin/firewall/transfer.rb
+++ b/lib/infrataster/plugin/firewall/transfer.rb
@@ -44,7 +44,8 @@ module Infrataster
             nc_option = @protocol == :udp ? '-w1 -u' : '-w1 -t'
             nc_option += @source_port ? " -p #{@source_port}" : ''
             @src_node.server
-              .ssh_exec("echo test|nc #{dest_addr} #{@dest_port} #{nc_option}")
+              .ssh_exec('echo test_with_infrataster | ' \
+                        + "nc #{dest_addr} #{@dest_port} #{nc_option}")
           end
           capture.result
         end

--- a/spec/unit/lib/infrataster/plugin/firewall/util_spec.rb
+++ b/spec/unit/lib/infrataster/plugin/firewall/util_spec.rb
@@ -7,7 +7,7 @@ module Infrataster
       describe Util do
         describe 'address' do
           before(:all) { Infrataster::Server.define(:src, '192.168.33.10') }
-          after(:all)  { Infrataster::Server.clear_all }
+          after(:all)  { Infrataster::Server.clear_defined_servers }
 
           context 'if node.server is given' do
             let(:node) { server(:src) }


### PR DESCRIPTION
Fix to netcat send udp packet correctly.

Netcat seems not to send udp packet when tiny string input.
`echo test | nc -u [destination] [port]`

But netcat sends packet correctly.
`echo test_with_infrataster | nc -u [destination] [port]`

Tests are all passed.
