### PR TITLE
Add feature to judge with ACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ describe server(:src) do
     it { is_expected.to be_reachable } #ICMP ping
     it { is_expected.to be_reachable.dest_port(80) } #TCP:80
     it { is_expected.to be_reachable.tcp.dest_port(80) }
+    it { is_expected.to be_reachable.tcp.dest_port(22).ack } # judge with both ACK and captured SYN
+    it { is_expected.to be_reachable.tcp.dest_port(22).ack(:only) } # judge with only ACK
     it { is_expected.to be_reachable.udp.dest_port(53) }
     it { is_expected.to be_reachable.dest_port('80/tcp') }
     it { is_expected.to be_reachable.dest_port('53/udp') }
@@ -42,13 +44,15 @@ server 'src'
     should reach to server 'dst'
     should reach to server 'dst' dest_port: 80
     should reach to server 'dst' tcp dest_port: 80
+    should reach to server 'dst' tcp dest_port: 22
+    should reach to server 'dst' tcp dest_port: 22
     should reach to server 'dst' udp dest_port: 53
     should reach to server 'dst' dest_port: 80/tcp
     should reach to server 'dst' dest_port: 53/udp
     should reach to server 'dst' tcp dest_port: 80 source_port: 30123
 
 Finished in 21.35 seconds (files took 0.7851 seconds to load)
-7 examples, 0 failures
+9 examples, 0 failures
 $
 ```
 

--- a/lib/infrataster/contexts/firewall_context.rb
+++ b/lib/infrataster/contexts/firewall_context.rb
@@ -56,6 +56,11 @@ module Infrataster
           @chain_string += " source_port: #{port}"
         end
 
+        chain :ack do |mode = :both|
+          @options ||= {}
+          @options.merge!(ack: mode)
+        end
+
         failure_message do
           s = "expected to reach to #{resource.dest_node}"
           s + "#{@chain_string}, but did not."

--- a/spec/integration/firewall_spec.rb
+++ b/spec/integration/firewall_spec.rb
@@ -2,9 +2,13 @@ require 'spec_helper'
 
 describe server(:src) do
   describe firewall(server(:dst)) do
-    it { is_expected.to be_reachable }
+    it {
+      is_expected.to be_reachable
+    }
     it { is_expected.to be_reachable.dest_port(80) }
     it { is_expected.to be_reachable.tcp.dest_port(80) }
+    it { is_expected.to be_reachable.tcp.dest_port(22).ack }
+    it { is_expected.to be_reachable.tcp.dest_port(22).ack(:only) }
     it { is_expected.to be_reachable.udp.dest_port(53) }
     it { is_expected.to be_reachable.dest_port('80/tcp') }
     it { is_expected.to be_reachable.dest_port('53/udp') }

--- a/spec/unit/lib/infrataster/contexts/firewall_context_spec.rb
+++ b/spec/unit/lib/infrataster/contexts/firewall_context_spec.rb
@@ -25,6 +25,9 @@ module Infrataster
       it 'should have chain `source_port`' do
         expect(context.be_reachable).to respond_to(:source_port)
       end
+      it 'should have chain `ack`' do
+        expect(context.be_reachable).to respond_to(:ack)
+      end
       it 'should have failure_message' do
         expect(context.be_reachable)
           .to respond_to(:failure_message)


### PR DESCRIPTION
Add `ack` chain to judge with ACK.

``` ruby
 describe server(:src) do
   describe firewall(server(:dst)) do
    it { is_expected.to be_reachable.tcp.dest_port(22).ack } # judge with both ACK and captured SYN
    it { is_expected.to be_reachable.tcp.dest_port(22).ack(:only) } # judge with only ACK
   end
 end
```
