### PR TITLE
add 'via' matcher

### DIFF
--- a/lib/infrataster/contexts/firewall_context.rb
+++ b/lib/infrataster/contexts/firewall_context.rb
@@ -18,7 +18,7 @@ module Infrataster
         end
 
         chain :via do |interface|
-          @options ||={}
+          @options ||= {}
           @options.merge!(interface: interface)
           @chain_string ||= ''
           @chain_string += " via interface: #{interface}"

--- a/lib/infrataster/contexts/firewall_context.rb
+++ b/lib/infrataster/contexts/firewall_context.rb
@@ -17,6 +17,13 @@ module Infrataster
           transfer.reachable?
         end
 
+        chain :via do |interface|
+          @options ||={}
+          @options.merge!(interface: interface)
+          @chain_string ||= ''
+          @chain_string += ' via'
+        end
+
         chain :icmp do
           @options ||= {}
           @options.merge!(protocol: :icmp) unless @options[:protocol]

--- a/lib/infrataster/contexts/firewall_context.rb
+++ b/lib/infrataster/contexts/firewall_context.rb
@@ -21,7 +21,7 @@ module Infrataster
           @options ||={}
           @options.merge!(interface: interface)
           @chain_string ||= ''
-          @chain_string += ' via'
+          @chain_string += " via interface: #{interface}"
         end
 
         chain :icmp do

--- a/lib/infrataster/plugin/firewall/capture.rb
+++ b/lib/infrataster/plugin/firewall/capture.rb
@@ -6,11 +6,11 @@ module Infrataster
       class Capture
         attr_reader :result, :output
 
-        def initialize(node, bpf = nil, interface = 'any', term_sec = 3)
+        def initialize(node, bpf = nil, interface = nil, term_sec = 3)
           @node = node.respond_to?(:server) ? node.server :
             Net::SSH.start(node, config: true)
           @bpf = bpf
-          @interface = interface
+          @interface = interface ? interface : 'any'
           @connected = false
           @term_sec = term_sec
           @thread = nil

--- a/lib/infrataster/plugin/firewall/capture.rb
+++ b/lib/infrataster/plugin/firewall/capture.rb
@@ -6,10 +6,11 @@ module Infrataster
       class Capture
         attr_reader :result, :output
 
-        def initialize(node, bpf = nil, term_sec = 3)
+        def initialize(node, bpf = nil, interface = 'any', term_sec = 3)
           @node = node.respond_to?(:server) ? node.server :
             Net::SSH.start(node, config: true)
           @bpf = bpf
+          @interface = interface
           @connected = false
           @term_sec = term_sec
           @thread = nil
@@ -94,7 +95,7 @@ module Infrataster
         end
 
         def capture_command
-          "sudo tcpdump -c1 -nnn -i any #{@bpf} > /dev/null && echo RECEIVED"
+          "sudo tcpdump -c1 -nnn -i #{@interface} #{@bpf} > /dev/null && echo RECEIVED"
         end
       end
     end

--- a/lib/infrataster/plugin/firewall/transfer.rb
+++ b/lib/infrataster/plugin/firewall/transfer.rb
@@ -11,6 +11,7 @@ module Infrataster
           @dest_port = options[:dest_port] ? options[:dest_port] : 80
           @source_port = options[:source_port] ? options[:source_port] : nil
           @ack = options[:ack] ? options[:ack] : nil
+          @interface = options[:interface] ? options[:interface] : nil
         end
 
         def reachable?
@@ -55,7 +56,7 @@ module Infrataster
           dest_addr = Util.address(@dest_node)
 
           bpf = Capture.bpf(bpf_options(src_addr, dest_addr))
-          capture = Capture.new(@dest_node, bpf)
+          capture = Capture.new(@dest_node, bpf, @interface)
           nc_result = nil
           capture.open do
             nc_result =


### PR DESCRIPTION
`tcpdump -i any` is supported only on Linux kernel. adding `via` is just a work around but better than nothing.

``` ruby
describe server(:fluentd1) do
  describe firewall(server(:fluentd1)) do
    it { is_expected.to be_reachable.via('lo0').dest_port(24284) }
  end 
end
```
