### PR TITLE
Fix lack of ssh.loop

### DIFF
--- a/lib/infrataster/plugin/firewall/capture.rb
+++ b/lib/infrataster/plugin/firewall/capture.rb
@@ -55,6 +55,7 @@ module Infrataster
                 output = run_check(channel)
                 @output << output.to_s
               end
+              ssh.loop
             end
           end
         end


### PR DESCRIPTION
This PR is to fix #6.

Net::Ssh::Channel needs `ssh.loop` to handle ssh events.
To handle ssh events, I have added `ssh.loop`.
